### PR TITLE
Implement proper PIMPL for ArrayHandle storage (#37)

### DIFF
--- a/cpp/include/array_handle.h
+++ b/cpp/include/array_handle.h
@@ -5,12 +5,12 @@
 
 #include "forge_handle.h"
 
-struct ArrayStorage {
-    void* metal_buffer_ = nullptr;
-    void* write_event_ = nullptr;
+struct ArrayStorage;
 
-    ~ArrayStorage();
-};
+#ifdef __OBJC__
+@protocol MTLBuffer;
+@protocol MTLCommandBuffer;
+#endif
 
 class ArrayHandle {
    private:
@@ -32,11 +32,13 @@ class ArrayHandle {
     size_t offset() const { return offset_; }
     std::span<const float> data() const;
     std::span<float> data();
-    void* metal_buffer() const { return storage_->metal_buffer_; }
+
+#ifdef __OBJC__
+    id<MTLBuffer> metal_buffer() const;
+    void set_event(id<MTLCommandBuffer> event);
+#endif
 
     // SETTER //
-    void set_metal_buffer(void* buf) { storage_->metal_buffer_ = buf; }
-    void set_event(void* event);
     void copy_from(std::shared_ptr<ArrayHandle> other, std::vector<int64_t> shape,
                    std::vector<int64_t> strides, size_t offset);
 

--- a/cpp/src/array_elementwise.mm
+++ b/cpp/src/array_elementwise.mm
@@ -46,7 +46,7 @@ std::shared_ptr<ArrayHandle> array_nullaryops(const std::vector<int64_t>& shape,
 
     id<MTLComputePipelineState> pipeline =
         (__bridge_transfer id<MTLComputePipelineState>)get_pipeline(op_name, METAL_SOURCE);
-    id<MTLBuffer> bufOut = (__bridge id<MTLBuffer>)out->metal_buffer();
+    id<MTLBuffer> bufOut = out->metal_buffer();
 
     id<MTLCommandBuffer> cmd = [queue commandBuffer];
     if (!cmd)
@@ -67,6 +67,6 @@ std::shared_ptr<ArrayHandle> array_nullaryops(const std::vector<int64_t>& shape,
 
     [cmd commit];
     fh->set_seed(seed + (uint32_t)numel);
-    out->set_event((__bridge void*)cmd);
+    out->set_event(cmd);
     return out;
 }

--- a/cpp/src/array_handle.mm
+++ b/cpp/src/array_handle.mm
@@ -5,10 +5,10 @@
 #include "../include/metal_source.h"
 #include "../include/metal_utils.h"
 
-ArrayStorage::~ArrayStorage() {
-    if (metal_buffer_) id old_buffer = (__bridge_transfer id)metal_buffer_;
-    if (write_event_) id old_event = (__bridge_transfer id)write_event_;
-}
+struct ArrayStorage {
+    id<MTLBuffer> metal_buffer = nil;
+    id<MTLCommandBuffer> write_event = nil;
+};
 
 ArrayHandle::ArrayHandle(std::vector<int64_t> shape, void* dev, bool zero)
     : shape_{std::move(shape)}, offset_(0), storage_(std::make_shared<ArrayStorage>()) {
@@ -20,7 +20,7 @@ ArrayHandle::ArrayHandle(std::vector<int64_t> shape, void* dev, bool zero)
     id<MTLBuffer> buf = [device newBufferWithLength:nbytes options:MTLResourceStorageModeShared];
     if (zero) memset(buf.contents, 0, nbytes);
 
-    storage_->metal_buffer_ = (__bridge_retained void*)buf;
+    storage_->metal_buffer = buf;
 }
 
 ArrayHandle::ArrayHandle(const float* src_data, std::vector<int64_t> shape, void* dev)
@@ -34,7 +34,7 @@ ArrayHandle::ArrayHandle(const float* src_data, std::vector<int64_t> shape, void
                                             length:nbytes
                                            options:MTLResourceStorageModeShared];
 
-    storage_->metal_buffer_ = (__bridge_retained void*)buf;
+    storage_->metal_buffer = buf;
 }
 
 ArrayHandle::ArrayHandle(const std::shared_ptr<ArrayHandle>& parent, std::vector<int64_t> new_shape,
@@ -47,26 +47,20 @@ ArrayHandle::ArrayHandle(const std::shared_ptr<ArrayHandle>& parent, std::vector
 std::span<float> ArrayHandle::data() {
     size_t total = numel_from_shape(shape_);
     if (total == 0) return {};
-    if (!storage_->metal_buffer_) {
+    if (!storage_->metal_buffer) {
         throw std::runtime_error(
             "ArrayHandle::data: no existing metal_buffer associated with ArrayHandle");
     }
-    id<MTLBuffer> buf = (__bridge id<MTLBuffer>)storage_->metal_buffer_;
-    float* src = (float*)[buf contents];
+    float* src = (float*)[storage_->metal_buffer contents];
 
     return std::span<float>(src, total);
 }
 
 std::span<const float> ArrayHandle::data() const { return const_cast<ArrayHandle*>(this)->data(); }
 
-void ArrayHandle::set_event(void* event) {
-    if (storage_->write_event_ == event) return;
-    if (storage_->write_event_) id old_event = (__bridge_transfer id)storage_->write_event_;
-    if (event)
-        storage_->write_event_ = (__bridge_retained void*)(__bridge id)event;
-    else
-        storage_->write_event_ = nullptr;
-}
+id<MTLBuffer> ArrayHandle::metal_buffer() const { return storage_->metal_buffer; }
+
+void ArrayHandle::set_event(id<MTLCommandBuffer> event) { storage_->write_event = event; }
 
 void ArrayHandle::copy_from(std::shared_ptr<ArrayHandle> other, std::vector<int64_t> shape,
                             std::vector<int64_t> strides, size_t offset) {
@@ -85,8 +79,8 @@ void ArrayHandle::copy_from(std::shared_ptr<ArrayHandle> other, std::vector<int6
         src_strides.assign(shape.size(), 0);
     }
 
-    [enc setBuffer:(__bridge id<MTLBuffer>)this->metal_buffer() offset:0 atIndex:0];
-    [enc setBuffer:(__bridge id<MTLBuffer>)other->metal_buffer() offset:0 atIndex:1];
+    [enc setBuffer:this->metal_buffer() offset:0 atIndex:0];
+    [enc setBuffer:other->metal_buffer() offset:0 atIndex:1];
 
     uint ndim = (uint)shape.size();
 
@@ -125,15 +119,13 @@ void ArrayHandle::copy_from(std::shared_ptr<ArrayHandle> other, std::vector<int6
     [enc dispatchThreads:gridSize threadsPerThreadgroup:threadgroupSize];
     [enc endEncoding];
     [cmd commit];
-    this->set_event((__bridge void*)cmd);
+    this->set_event(cmd);
 }
 
 void ArrayHandle::synchronize() {
-    if (!storage_->write_event_) return;
-    id<MTLCommandBuffer> cmd = (__bridge id<MTLCommandBuffer>)storage_->write_event_;
-    [cmd waitUntilCompleted];
-    id cmd_to_release = (__bridge_transfer id)storage_->write_event_;
-    storage_->write_event_ = nullptr;
+    if (!storage_->write_event) return;
+    [storage_->write_event waitUntilCompleted];
+    storage_->write_event = nil;
 }
 
 std::vector<int64_t> array_shape(const std::shared_ptr<ArrayHandle>& h) { return h->shape(); }

--- a/cpp/src/array_matmul.mm
+++ b/cpp/src/array_matmul.mm
@@ -111,9 +111,9 @@ std::shared_ptr<ArrayHandle> array_matmul(const std::shared_ptr<ArrayHandle>& A,
                                                                                 alpha:1.0
                                                                                  beta:0.0];
 
-    id<MTLBuffer> bufA = (__bridge id<MTLBuffer>)a->metal_buffer();
-    id<MTLBuffer> bufB = (__bridge id<MTLBuffer>)b->metal_buffer();
-    id<MTLBuffer> bufC = (__bridge id<MTLBuffer>)c->metal_buffer();
+    id<MTLBuffer> bufA = a->metal_buffer();
+    id<MTLBuffer> bufB = b->metal_buffer();
+    id<MTLBuffer> bufC = c->metal_buffer();
 
     // total_ops only counts batch dimensions (not M, N)
     size_t total_ops = 1;
@@ -150,7 +150,7 @@ std::shared_ptr<ArrayHandle> array_matmul(const std::shared_ptr<ArrayHandle>& A,
     }
 
     [cmd commit];
-    c->set_event((__bridge void*)cmd);
+    c->set_event(cmd);
 
     std::vector<int64_t> final_shape = c->shape();
     if (squeeze_a && squeeze_b) {

--- a/cpp/src/array_sum.mm
+++ b/cpp/src/array_sum.mm
@@ -19,8 +19,8 @@ std::shared_ptr<ArrayHandle> sum_global(const std::shared_ptr<ArrayHandle>& A, b
 
     auto out = std::make_shared<ArrayHandle>(out_shape, defaultForgeHandle->device_ptr());
 
-    id<MTLBuffer> bufA = (__bridge id<MTLBuffer>)A->metal_buffer();
-    id<MTLBuffer> bufOut = (__bridge id<MTLBuffer>)out->metal_buffer();
+    id<MTLBuffer> bufA = A->metal_buffer();
+    id<MTLBuffer> bufOut = out->metal_buffer();
 
     id<MTLCommandBuffer> cmd = [queue commandBuffer];
     if (!cmd) throw std::runtime_error("Metal Error: Failed to create command buffer.");
@@ -57,7 +57,7 @@ std::shared_ptr<ArrayHandle> sum_global(const std::shared_ptr<ArrayHandle>& A, b
     [enc endEncoding];
 
     [cmd commit];
-    out->set_event((__bridge void*)cmd);
+    out->set_event(cmd);
 
     return out;
 }
@@ -83,8 +83,8 @@ std::shared_ptr<ArrayHandle> sum_axis(const std::shared_ptr<ArrayHandle>& A, siz
 
     if (out_numel == 0) return out;
 
-    id<MTLBuffer> bufA = (__bridge id<MTLBuffer>)A->metal_buffer();
-    id<MTLBuffer> bufOut = (__bridge id<MTLBuffer>)out->metal_buffer();
+    id<MTLBuffer> bufA = A->metal_buffer();
+    id<MTLBuffer> bufOut = out->metal_buffer();
 
     id<MTLCommandBuffer> cmd = [queue commandBuffer];
     if (!cmd) throw std::runtime_error("Metal Error: Failed to create command buffer.");
@@ -127,7 +127,7 @@ std::shared_ptr<ArrayHandle> sum_axis(const std::shared_ptr<ArrayHandle>& A, siz
     [enc endEncoding];
 
     [cmd commit];
-    out->set_event((__bridge void*)cmd);
+    out->set_event(cmd);
 
     return out;
 }

--- a/cpp/src/metal_utils.mm
+++ b/cpp/src/metal_utils.mm
@@ -63,12 +63,12 @@ std::shared_ptr<ArrayHandle> launch_elementwise(
 
     NSUInteger slot = 0;
     for (const auto& inp : inputs) {
-        [enc setBuffer:(__bridge id<MTLBuffer>)inp->metal_buffer() offset:0 atIndex:slot++];
+        [enc setBuffer:inp->metal_buffer() offset:0 atIndex:slot++];
     }
     auto out = dedicated_out ? std::make_shared<ArrayHandle>(out_shape, fh->device_ptr())
                              : *std::begin(inputs);
     if (dedicated_out) {
-        id<MTLBuffer> out_metalbuf = (__bridge id<MTLBuffer>)out->metal_buffer();
+        id<MTLBuffer> out_metalbuf = out->metal_buffer();
         [enc setBuffer:out_metalbuf offset:0 atIndex:slot++];
     }
 
@@ -108,6 +108,6 @@ std::shared_ptr<ArrayHandle> launch_elementwise(
     [enc endEncoding];
 
     [cmd commit];
-    out->set_event((__bridge void*)cmd);
+    out->set_event(cmd);
     return out;
 }

--- a/cpp/src/runtime.mm
+++ b/cpp/src/runtime.mm
@@ -42,9 +42,9 @@ std::shared_ptr<ArrayHandle> Graph::execute(std::vector<std::shared_ptr<ArrayHan
     // Helper to find which buffers a node's I/O refers to: (inputHandle, Arena or outputHandle)
     auto get_metal_buffer_for_node = [&](int node_idx) -> id<MTLBuffer> {
         int root = this->arena->get_root(node_idx);
-        if (root == output_root) return (__bridge id<MTLBuffer>)output_handle->metal_buffer();
+        if (root == output_root) return output_handle->metal_buffer();
         if (this->nodes[root].op == OpCode::INPUT) {
-            return (__bridge id<MTLBuffer>)inputs[root]->metal_buffer();
+            return inputs[root]->metal_buffer();
         }
         return arena_buffer;
     };
@@ -86,6 +86,6 @@ std::shared_ptr<ArrayHandle> Graph::execute(std::vector<std::shared_ptr<ArrayHan
     }
     [computeEncoder endEncoding];
     [commandBuffer commit];
-    output_handle->set_event((__bridge void*)commandBuffer);
+    output_handle->set_event(commandBuffer);
     return output_handle;
 }


### PR DESCRIPTION
Closes #37.

## Problem
`ArrayStorage` stored its Metal objects as `void*` in the public header, so:
- pure C++ translation units (`bindings*.cpp`, `compiler.cpp`) were exposed to GPU internals through `void*`,
- every `.mm` call site had to `(__bridge id<MTLBuffer>)`-cast the result, with no compiler checking, and
- ownership was hand-managed via `__bridge_retained` / `__bridge_transfer` plus a manual `~ArrayStorage()`.

## Change
Proper PIMPL: `ArrayStorage` is now an **opaque forward declaration** in `array_handle.h` and is **defined in `array_handle.mm`** with real ARC-managed members:

```objc
struct ArrayStorage {
    id<MTLBuffer> metal_buffer = nil;
    id<MTLCommandBuffer> write_event = nil;
};
```

- Metal-typed accessors (`metal_buffer()`, `set_event()`) are exposed **only to Objective-C++** via an `#ifdef __OBJC__` block (forward-declaring `@protocol MTLBuffer/MTLCommandBuffer`). C++ files never see Metal types.
- ARC owns the strong references, so the manual destructor and all bridge-retain/transfer casts are gone.
- The redundant `(__bridge id<MTLBuffer>)` / `(__bridge void*)` casts at the 5 `.mm` call sites (`array_elementwise`, `array_matmul`, `array_sum`, `metal_utils`, `runtime`) are removed.
- Dropped the unused `set_metal_buffer()`.

Views still share one `ArrayStorage` through the `shared_ptr` — the deleter is captured at `make_shared` time (in the `.mm`), so an incomplete type works fine.

## Testing
- Clean rebuild; pure-C++ binding files compile against the opaque type.
- `pytest`: **75 passed, 3 failed**. The 3 failures (`test_exp_correct`, `test_fexp`, `test_exp10_correct`) are pre-existing `MTLMathModeFast` precision diffs — verified they fail **identically on clean `main`** without this diff. No regressions.

## Out of scope / follow-up
`get_pipeline()` in `metal_utils.h` still returns `void*` (a similar leak for pipeline state, not array storage) — a natural follow-up if we want the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)